### PR TITLE
add section warning about web3 http provider sendAsync to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,24 @@ await ethrDid.createSigningDelegate() // Adds a signing delegate valid for 1 day
 
 See section on adding delegates below.
 
+**Note when using `HttpProvider` from `web3.js v1.0.0`:** There is an [issue](https://github.com/ethereum/web3.js/issues/1119) where the `sendAsync` function is undefined.  In order to avoid errors resulting from this, please configure `EthrDID` using a different HTTP provider such as the one from `ethjs`:
+
+```js
+import HttpProvider from 'ethjs-provider-http'
+const provider = new HttpProvider('http://localhost:8545')
+const ethrDid = new EthrDID({provider, address, registry})
+```
+
+or manually assign `sendAsync` before creating an instance of the `web3` provider
+
+```js
+import Web3 from 'web3'
+Web3.providers.HttpProvider.prototype.sendAsync = Web3.providers.HttpProvider.prototype.send
+const provider = new Web3.providers.HttpProvider('http://localhost:8545')
+const ethrDid = new EthrDID({provider, address, registry})
+```
+
+
 #### Ethereum Web3 Wallet developers
 
 You can easily add support for signing yourself by implementing a signer function with a clean GUI. See [DID-JWT Signer Functions](https://github.com/uport-project/did-jwt#signer-functions).


### PR DESCRIPTION
The reported issue is caused by an issue originating from a specific version of a user-supplied third party dependency.

I propose addressing it by including a section in the readme to warn developers about when it occurs and providing a couple workarounds.  The rationale is that fixing the root issue is outside the responsibility of this library, and changing code to deal with the specific scenario is a bad pattern for a variety of reasons.

I also considered checking for an undefined `sendAsync` in `configureProvider()` and logging a warning to the user, but generalizing that to validating the entire `provider` object doesn't seem like a great idea.  What do people think about that?

Any suggestions for alternate ways to either communicate or supply a fix for this issue are welcome.