### PR TITLE
Add rsk support

### DIFF
--- a/src/__tests__/index-test.js
+++ b/src/__tests__/index-test.js
@@ -13,7 +13,13 @@ function sleep (seconds) {
   return new Promise(resolve => setTimeout(resolve, seconds * 1000))
 }
 
-describe('EthrDID', () => {
+const namesAndMethods = [
+  ['ethereum', null, null],
+  ['ethereum - method ethr', null, 'ethr'],
+  ['rsk - method ethr:rsk', 'rsk', 'ethr:rsk']
+]
+
+describe.each(namesAndMethods)('EthrDID %s', (_, name, method) => {
   let ethrDid,
     plainDid,
     registry,
@@ -43,21 +49,40 @@ describe('EthrDID', () => {
     owner = accounts[2].toLowerCase()
     delegate1 = accounts[3].toLowerCase()
     delegate2 = accounts[4].toLowerCase()
-    did = `did:ethr:${identity}`
+    did = `did:${method || 'ethr'}:${identity}`
 
     registry = await DidReg.new({
       from: accounts[0],
       gasPrice: 100000000000,
       gas: 4712388
     })
-    ethrDid = new EthrDID({
-      provider,
-      registry: registry.address,
-      address: identity
-    })
-    resolver = new Resolver(
-      getResolver({ provider, registry: registry.address })
-    )
+
+    if (method) {
+      ethrDid = new EthrDID({
+        provider,
+        registry: registry.address,
+        address: identity,
+        method
+      })
+    } else {
+      ethrDid = new EthrDID({
+        provider,
+        registry: registry.address,
+        address: identity
+      })
+    }
+
+    if (name) {
+      resolver = new Resolver(
+        getResolver({
+          networks: [{ provider, registry: registry.address, name }]
+        })
+      )
+    } else {
+      resolver = new Resolver(
+        getResolver({ provider, registry: registry.address })
+      )
+    }
   })
 
   describe('presets', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,7 @@ export default class EthrDID {
     this.registry = DidReg.at(registryAddress)
     this.address = conf.address
     if (!this.address) throw new Error('No address is set for EthrDid')
-    this.did = `did:ethr:${this.address}`
+    this.did = `did:${conf.method || 'ethr'}:${this.address}`
     if (conf.signer) {
       this.signer = conf.signer
     } else if (conf.privateKey) {


### PR DESCRIPTION
Hi!

For RSK we are appending `rsk:` or `rsk:testnet:` to the method identifier. The library is fully compatible with RSK deployment so it would be great if we could change the method name seamlessly. 

Cheers,