### PR TITLE
fix: add esm wrapper

### DIFF
--- a/esm/index.js
+++ b/esm/index.js
@@ -1,0 +1,3 @@
+import cjsModule from '../lib/index.js';
+
+export default cjsModule

--- a/esm/package.json
+++ b/esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/package.json
+++ b/package.json
@@ -3,21 +3,21 @@
   "version": "2.3.2",
   "description": "Create, manage and use did:ethr identifiers",
   "type": "module",
-  "source": "src/index.ts",
-  "main": "./lib/index.cjs",
-  "module": "./lib/index.module.js",
-  "unpkg": "./lib/index.umd.js",
+  "source": "./src/index.ts",
+  "main": "./lib/index.js",
+  "module": "./esm/index.js",
   "types": "./lib/index.d.ts",
-  "umd:main": "./lib/index.umd.js",
   "files": [
     "lib",
+    "esm",
     "src",
     "LICENSE"
   ],
   "exports": {
     ".": {
-      "require": "./lib/index.cjs",
-      "import": "./lib/index.module.js"
+      "types": "./lib/index.d.ts",
+      "import": "./esm/index.js",
+      "require": "./lib/index.js"
     }
   },
   "repository": {
@@ -32,7 +32,8 @@
   "scripts": {
     "test": "jest",
     "test:ci": "jest --coverage",
-    "build": "microbundle --compress=false",
+    "build": "tsc",
+    "clean": "rm -rf ./lib",
     "format": "prettier --write \"src/**/*.[jt]s\"",
     "lint": "eslint --ignore-pattern \"src/**/*.test.[jt]s\" \"src/**/*.[jt]s\"",
     "prepublishOnly": "yarn test:ci && yarn format && yarn lint",
@@ -85,6 +86,6 @@
     "@ethersproject/wallet": "^5.6.2",
     "did-jwt": "^6.3.0",
     "did-resolver": "^4.0.0",
-    "ethr-did-resolver": "^6.2.3"
+    "ethr-did-resolver": "alpha"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4826,10 +4826,10 @@ ethr-did-registry@0.0.3:
   resolved "https://registry.yarnpkg.com/ethr-did-registry/-/ethr-did-registry-0.0.3.tgz#f363d2c73cb9572b57bd7a5c9c90c88485feceb5"
   integrity sha512-4BPvMGkxAK9vTduCq6D5b8ZqjteD2cvDIPPriXP6nnmPhWKFSxypo+AFvyQ0omJGa0cGTR+dkdI/8jiF7U/qaw==
 
-ethr-did-resolver@^6.2.3:
-  version "6.2.3"
-  resolved "https://registry.yarnpkg.com/ethr-did-resolver/-/ethr-did-resolver-6.2.3.tgz#31596913c000d214c49a103c28472df36f9ce508"
-  integrity sha512-SssU7Rp70mq8CIudlrRAZnbRS/UPfdk8ROlLBVXNXlErdjAzXttfW7zTCDY3TvuBBelxM+uSOkKifX+WiphaZg==
+ethr-did-resolver@alpha:
+  version "7.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/ethr-did-resolver/-/ethr-did-resolver-7.0.0-alpha.1.tgz#c9eab38f65b0537520bbee33a86ebe6ca248cb07"
+  integrity sha512-N/l49Kz85GLU2uILt0wa+LWLyriuHhFU6ZglhfIu+GjjcdcyktzDg9VWRaPH1XKzRZmbtrpM+YNBlNHsogbTog==
   dependencies:
     "@ethersproject/abi" "^5.6.3"
     "@ethersproject/abstract-signer" "^5.6.2"


### PR DESCRIPTION
Adds the same esm module wrapping like in: https://github.com/decentralized-identity/ethr-did-resolver/commit/d2bbeafbd2d77308f12d73f952b0b9940431dd83

Also updated ethr-did-resolver to alpha to test the esm module from there as well already and it seems to work. We could add a alpha release channel here as well. Not sure though. 