### PR TITLE
fix: missing provider error in ethrDid.setAttribute

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,7 @@ export class EthrDID {
     if (conf.provider || conf.rpcUrl || conf.web3) {
       let txSigner = conf.txSigner
       if (conf.privateKey && typeof txSigner === 'undefined') {
-        txSigner = new Wallet(conf.privateKey)
+        txSigner = new Wallet(conf.privateKey, conf.provider || conf.web3?.currentProvider)
       }
       this.controller = new EthrDidController(
         conf.identifier,


### PR DESCRIPTION
### Description of Changes

In the `EthrDID` class constructor, when the following code executes:

```javascript
if (conf.privateKey && typeof txSigner === 'undefined') {
    txSigner = new Wallet(conf.privateKey);
}
```

it causes an error if no `provider` is set. The issue occurs in `node_modules\ethers\src.ts\providers\abstract-signer.ts` at:

```typescript
function checkProvider(signer: AbstractSigner, operation: string): Provider {
    if (signer.provider) { return signer.provider; }
    assert(false, "missing provider", "UNSUPPORTED_OPERATION", { operation });
}
```

#### Error Message:
```
Error: missing provider (operation="sendTransaction", code=UNSUPPORTED_OPERATION, version=abstract-signer/5.5.0)
reason: 'missing provider',
code: 'UNSUPPORTED_OPERATION',
operation: 'sendTransaction'
```

#### Fix:
The issue was resolved by modifying the `txSigner` initialization to include the provider:

```javascript
txSigner = new Wallet(conf.privateKey, conf.provider || conf.web3?.currentProvider);
```
This ensures a valid provider is passed, preventing the error.

### Related Issue

fixes #81